### PR TITLE
fix/active-organization-session

### DIFF
--- a/packages/payload-auth/src/better-auth/plugin/constants.ts
+++ b/packages/payload-auth/src/better-auth/plugin/constants.ts
@@ -114,7 +114,6 @@ export const baModelFieldKeysToFieldNames = {
   },
   session: {
     userId: 'user',
-    activeOrganizationId: 'activeOrganization',
   },
   member: {
     organizationId: 'organization',


### PR DESCRIPTION
# What / Why?

- Reverts the default field name for "Active Organization" when using the `organization` plugin (`activeOrganization` --> `activeOrganisationId`)
- Payload [expects](https://github.com/better-auth/better-auth/blob/492b5cc2745241b3f804b5853f922c2807aa668b/packages/better-auth/src/plugins/organization/routes/crud-org.ts#L592) `activeOrganizationId` and not `activeOrganization` so the APIs for getting the active organization would fail (return null) despite it being set correctly in the session table.

# Notes

I patched my local version with this change and it fixed the issue. I wasn't sure if there was any CI/tests that needed updating here.