### PR TITLE
chore: add auto-rebuild for payload-auth package in dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "clean-all": "find . -type d -name node_modules -o -name dist -o -name .turbo -o -name .next -o -type f -name tsconfig.tsbuildinfo -o -name pnpm-lock.yaml | xargs rm -rf",
     "build": "turbo run build --filter=./packages/payload-auth",
     "publish": "cd packages/payload-auth && pnpm publish --access public",
-    "dev": "cd demo && pnpm dev",
+    "dev": "turbo run dev --filter=./packages/payload-auth --filter=./demo",
     "format": "prettier . --write"
   },
   "keywords": [

--- a/packages/payload-auth/package.json
+++ b/packages/payload-auth/package.json
@@ -45,6 +45,8 @@
   "scripts": {
     "clean": "rm -rf ./dist && rm -rf ./tsconfig.tsbuildinfo",
     "build": "pnpm clean && pnpm copyfiles && pnpm build:types && pnpm build:swc",
+    "dev": "pnpm build && pnpm dev:watch",
+    "dev:watch": "swc ./src -d ./dist --config-file .swcrc --strip-leading-paths --watch",
     "copyfiles": "copyfiles -u 1 --exclude \"src/better-auth/adapter/tests/**/*\" \"src/**/*.{html,css,scss,ttf,woff,woff2,eot,svg,jpg,png,json}\" dist",
     "build:swc": "swc ./src -d ./dist --config-file .swcrc --strip-leading-paths",
     "build:types": "pnpm generate:better-auth-types && tsc --project tsconfig.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
     dependencies:
       '@daveyplate/better-auth-ui':
         specifier: 3.2.5
-        version: 3.2.5(62umj76noox332dbthfz44zrga)
+        version: 3.2.5(3d7fbed157585ceafbff9e83ed7887d8)
       '@payloadcms/db-vercel-postgres':
         specifier: 3.59.1
         version: 3.59.1(@types/pg@8.11.6)(kysely@0.28.8)(payload@3.59.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))
@@ -475,7 +475,7 @@ importers:
         version: 1.3.27(better-auth@1.3.27(next@15.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.77.4))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       '@better-auth/stripe':
         specifier: 1.3.27
-        version: 1.3.27(@better-auth/core@1.3.27)(better-auth@1.3.27(next@15.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.77.4))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(stripe@18.5.0(@types/node@20.19.20))
+        version: 1.3.27(@better-auth/core@1.3.27)(better-auth@1.3.27(next@15.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.77.4))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(stripe@18.5.0(@types/node@20.19.21))
       '@payloadcms/db-postgres':
         specifier: '>3.55.1 <4'
         version: 3.59.1(@vercel/postgres@0.9.0)(kysely@0.28.8)(payload@3.59.1(bufferutil@4.0.9)(graphql@16.11.0)(typescript@5.8.2)(utf-8-validate@6.0.5))
@@ -493,7 +493,7 @@ importers:
         version: 1.11.13(@swc/helpers@0.5.15)
       '@types/node':
         specifier: ^20.0.0
-        version: 20.19.20
+        version: 20.19.21
       '@types/react':
         specifier: ^19
         version: 19.1.2
@@ -520,7 +520,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: ^1.0.0
-        version: 1.6.1(@types/node@20.19.20)(lightningcss@1.29.2)(sass@1.77.4)
+        version: 1.6.1(@types/node@20.19.21)(lightningcss@1.29.2)(sass@1.77.4)
 
 packages:
 
@@ -1795,8 +1795,8 @@ packages:
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
-  '@monaco-editor/loader@1.5.0':
-    resolution: {integrity: sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==}
+  '@monaco-editor/loader@1.6.0':
+    resolution: {integrity: sha512-PdWBZkPb2Amc1kxRsIEyQFkAya6PzUvSf4waXMPt7I05Azm4e2hQuViBVjfw1Mmck98GG2TqecLzWtg1tbyriw==}
 
   '@monaco-editor/react@4.7.0':
     resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
@@ -2049,8 +2049,8 @@ packages:
   '@octokit/types@15.0.0':
     resolution: {integrity: sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==}
 
-  '@orama/orama@3.1.15':
-    resolution: {integrity: sha512-ltjr1WHlY+uqEKE0JG2G6Xn36mSQGmPdPGQedQyipekBdf0iAtp8oL9dckQRX8cP+nUfOZwwPWSu7km8gGciUg==}
+  '@orama/orama@3.1.16':
+    resolution: {integrity: sha512-scSmQBD8eANlMUOglxHrN1JdSW8tDghsPuS83otqealBiIeMukCQMOf/wc0JJjDXomqwNdEQFLXLGHrU6PGxuA==}
     engines: {node: '>= 20.0.0'}
 
   '@oxc-transform/binding-android-arm64@0.75.1':
@@ -3625,8 +3625,8 @@ packages:
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
-  '@types/node@20.19.20':
-    resolution: {integrity: sha512-2Q7WS25j4pS1cS8yw3d6buNCVJukOTeQ39bAnwR6sOJbaxvyCGebzTMypDFN82CxBLnl+lSWVdCCWbRY6y9yZQ==}
+  '@types/node@20.19.21':
+    resolution: {integrity: sha512-CsGG2P3I5y48RPMfprQGfy4JPRZ6csfC3ltBZSRItG3ngggmNY/qs2uZKp4p9VbrpqNNSMzUZNFZKzgOGnd/VA==}
 
   '@types/node@22.13.11':
     resolution: {integrity: sha512-iEUCUJoU0i3VnrCmgoWCXttklWcvoCIx4jzcP22fioIVSdTmjgoEvmAO/QPw6TcS9k5FrNgn4w7q5lGOd1CT5g==}
@@ -4268,8 +4268,8 @@ packages:
   camelize@1.0.1:
     resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
 
-  caniuse-lite@1.0.30001749:
-    resolution: {integrity: sha512-0rw2fJOmLfnzCRbkm8EyHL8SvI2Apu5UbnQuTsJ0ClgrH8hcwFooJ1s5R0EP8o8aVrFu8++ae29Kt9/gZAZp/Q==}
+  caniuse-lite@1.0.30001750:
+    resolution: {integrity: sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -9020,12 +9020,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@better-auth/stripe@1.3.27(@better-auth/core@1.3.27)(better-auth@1.3.27(next@15.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.77.4))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(stripe@18.5.0(@types/node@20.19.20))':
+  '@better-auth/stripe@1.3.27(@better-auth/core@1.3.27)(better-auth@1.3.27(next@15.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.77.4))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(stripe@18.5.0(@types/node@20.19.21))':
     dependencies:
       '@better-auth/core': 1.3.27
       better-auth: 1.3.27(next@15.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.77.4))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       defu: 6.1.4
-      stripe: 18.5.0(@types/node@20.19.20)
+      stripe: 18.5.0(@types/node@20.19.21)
       zod: 4.1.12
 
   '@better-auth/utils@0.3.0': {}
@@ -9049,7 +9049,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@daveyplate/better-auth-ui@3.2.5(62umj76noox332dbthfz44zrga)':
+  '@daveyplate/better-auth-ui@3.2.5(3d7fbed157585ceafbff9e83ed7887d8)':
     dependencies:
       '@better-fetch/fetch': 1.1.18
       '@daveyplate/better-auth-tanstack': 1.3.6(@tanstack/query-core@5.90.2)(@tanstack/react-query@5.90.2(react@19.2.0))(better-auth@1.3.27(next@15.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.77.4))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -10036,13 +10036,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@monaco-editor/loader@1.5.0':
+  '@monaco-editor/loader@1.6.0':
     dependencies:
       state-local: 1.0.7
 
   '@monaco-editor/react@4.7.0(monaco-editor@0.54.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@monaco-editor/loader': 1.5.0
+      '@monaco-editor/loader': 1.6.0
       monaco-editor: 0.54.0
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -10243,7 +10243,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 26.0.0
 
-  '@orama/orama@3.1.15': {}
+  '@orama/orama@3.1.16': {}
 
   '@oxc-transform/binding-android-arm64@0.75.1':
     optional: true
@@ -12133,7 +12133,7 @@ snapshots:
       '@types/node': 22.13.11
       form-data: 4.0.4
 
-  '@types/node@20.19.20':
+  '@types/node@20.19.21':
     dependencies:
       undici-types: 6.21.0
 
@@ -12909,7 +12909,7 @@ snapshots:
 
   camelize@1.0.1: {}
 
-  caniuse-lite@1.0.30001749: {}
+  caniuse-lite@1.0.30001750: {}
 
   ccount@2.0.1: {}
 
@@ -14418,7 +14418,7 @@ snapshots:
   fumadocs-core@15.1.2(@types/react@19.1.2)(next@15.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.77.4))(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
-      '@orama/orama': 3.1.15
+      '@orama/orama': 3.1.16
       '@shikijs/rehype': 3.13.0
       '@shikijs/transformers': 3.13.0
       github-slugger: 2.0.0
@@ -15962,7 +15962,7 @@ snapshots:
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001749
+      caniuse-lite: 1.0.30001750
       postcss: 8.4.31
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -17565,11 +17565,11 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  stripe@18.5.0(@types/node@20.19.20):
+  stripe@18.5.0(@types/node@20.19.21):
     dependencies:
       qs: 6.14.0
     optionalDependencies:
-      '@types/node': 20.19.20
+      '@types/node': 20.19.21
 
   strnum@2.1.1: {}
 
@@ -18107,13 +18107,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@1.6.1(@types/node@20.19.20)(lightningcss@1.29.2)(sass@1.77.4):
+  vite-node@1.6.1(@types/node@20.19.21)(lightningcss@1.29.2)(sass@1.77.4):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.20(@types/node@20.19.20)(lightningcss@1.29.2)(sass@1.77.4)
+      vite: 5.4.20(@types/node@20.19.21)(lightningcss@1.29.2)(sass@1.77.4)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -18125,18 +18125,18 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.20(@types/node@20.19.20)(lightningcss@1.29.2)(sass@1.77.4):
+  vite@5.4.20(@types/node@20.19.21)(lightningcss@1.29.2)(sass@1.77.4):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.52.4
     optionalDependencies:
-      '@types/node': 20.19.20
+      '@types/node': 20.19.21
       fsevents: 2.3.3
       lightningcss: 1.29.2
       sass: 1.77.4
 
-  vitest@1.6.1(@types/node@20.19.20)(lightningcss@1.29.2)(sass@1.77.4):
+  vitest@1.6.1(@types/node@20.19.21)(lightningcss@1.29.2)(sass@1.77.4):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -18155,11 +18155,11 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.20(@types/node@20.19.20)(lightningcss@1.29.2)(sass@1.77.4)
-      vite-node: 1.6.1(@types/node@20.19.20)(lightningcss@1.29.2)(sass@1.77.4)
+      vite: 5.4.20(@types/node@20.19.21)(lightningcss@1.29.2)(sass@1.77.4)
+      vite-node: 1.6.1(@types/node@20.19.21)(lightningcss@1.29.2)(sass@1.77.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.19.20
+      '@types/node': 20.19.21
     transitivePeerDependencies:
       - less
       - lightningcss

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,4 +9,5 @@ onlyBuiltDependencies:
   - core-js
   - esbuild
   - sharp
+  - unrs-resolver
   - utf-8-validate

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,11 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
+    },
+    "dev": {
+      "dependsOn": ["^build"],
+      "cache": false,
+      "persistent": true
     }
   }
 }


### PR DESCRIPTION
### Summary
Added watch mode for `payload-auth` package to automatically rebuild on code changes during development. No more manual rebuilds needed!

### Changes
**packages/payload-auth/package.json**
- Added `dev` and `dev:watch` scripts using SWC watch mode

**turbo.json**
- Added `dev` task with `persistent: true` and `cache: false`

**package.json**
- Updated `dev` script to run both package watch and demo app in parallel

### Usage
```bash
pnpm dev