### PR TITLE
fix: return origin hooks from better auth options as promise. 

### DIFF
--- a/packages/payload-auth/src/better-auth/plugin/lib/sanitize-better-auth-options/utils/admin-before-role-middleware.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/sanitize-better-auth-options/utils/admin-before-role-middleware.ts
@@ -15,7 +15,7 @@ export function adminBeforeRoleMiddleware({ sanitizedOptions }: { sanitizedOptio
       }
     }
     if (typeof originalBefore === 'function') {
-      originalBefore(ctx)
+      return originalBefore(ctx)
     }
   })
 }


### PR DESCRIPTION
e.g. an APIError thrown from betterAuthOptions will not work.

```
hooks: {
    before: createAuthMiddleware(async ctx => {
            if (ctx.path !== '/update-user') {
                return
            }
            if (ctx.body?.name === undefined) return
            const name = ctx.body.name as string
            if (name.length < 2 || name.length > 32) {
                throw new APIError('BAD_REQUEST', {
                    message: 'name must be between 2 and 32 characters long'
                })
            }
        })
}
```