### PR TITLE
fix: make organizationRole join field conditional

### DIFF
--- a/packages/payload-auth/src/better-auth/plugin/lib/build-collections/organizations.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/build-collections/organizations.ts
@@ -93,8 +93,14 @@ export function buildOrganizationsCollection({
       ),
       maxDepth: 1,
       saveToJWT: false
-    },
-    {
+    }
+  ];
+
+  // Only add organizationRole join if the schema exists and has the organizationId field
+  // This prevents InvalidFieldJoin errors when dynamicAccessControl is not enabled
+  const organizationRoleSchema = resolvedSchemas[baModelKey.organizationRole];
+  if (organizationRoleSchema?.fields?.organizationId) {
+    joinFields.push({
       label: "Organization Roles",
       name: baModelKey.organizationRole,
       type: "join",
@@ -107,8 +113,8 @@ export function buildOrganizationsCollection({
       ),
       maxDepth: 1,
       saveToJWT: false
-    }
-  ];
+    });
+  }
 
   let organizationCollection: CollectionConfig = {
     ...existingOrganizationCollection,


### PR DESCRIPTION
## Summary

The `organizationRole` join field on the organizations collection was being added unconditionally, causing `InvalidFieldJoin` errors when the `organizationRole` schema doesn't have the `organizationId` field.

This happens when:
- `dynamicAccessControl` is not enabled on the organization plugin
- The `organizationRole` schema isn't fully resolved by Better Auth

## Error

```
InvalidFieldJoin: Invalid join field organizationRole. The config does not have a field 'organizationId' in collection 'organizationRole'
```

## Fix

Check if the `organizationRole` schema exists and has the `organizationId` field before adding the join field to the organizations collection.

## Related

- Fixes issue described in #126
- Complements the fix in #127 (which addresses the model key mapping)

🤖 Generated with [Claude Code](https://claude.ai/code)