### PR TITLE
fix: outputTransform - convert role field to comma separated string t…

### DIFF
--- a/packages/payload-auth/src/better-auth/adapter/transform/index.ts
+++ b/packages/payload-auth/src/better-auth/adapter/transform/index.ts
@@ -495,7 +495,12 @@ export const createTransform = (
         result[targetFieldKey] = String(value);
         return;
       }
-
+	    
+      // Convert role array to comma seprated string
+      if ((targetFieldKey === "role" || targetFieldKey === "roles") && Array.isArray(result[targetFieldKey])) {
+				result[targetFieldKey] = result[targetFieldKey].join(",")
+			}
+      
       // Flatten join results from { docs: [...] } to plain arrays
       if (isJoinResult(value)) {
         debugLog([


### PR DESCRIPTION
fix: outputTransform - convert role field to comma separated string to match better-auth schema. 

Adds a condition that if a fieldname called role or roles has an array value we convert it to a single comma seperated string. 

This matches the better auth schema for both `user.role` with the admin plugin and `member.role` with the organization plugin