### PR TITLE
security: strip secrets from pluginOptions before passing as serverProps

### DIFF
--- a/packages/payload-auth/src/better-auth/plugin/lib/apply-ba-admin-config.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/apply-ba-admin-config.ts
@@ -7,6 +7,7 @@ import {
 } from "../constants";
 import { checkPluginExists } from "../helpers/check-plugin-exists";
 import type { BetterAuthSchemas, PayloadAuthOptions } from "../types";
+import { stripSecretsFromPluginOptions } from "./strip-secrets";
 
 /**
  * Applies Better Auth admin UI overrides to the Payload config.
@@ -24,6 +25,11 @@ export function applyBetterAuthAdminConfig({
   collectionMap: Record<string, CollectionConfig>;
   resolvedBetterAuthSchemas: BetterAuthSchemas;
 }): void {
+  // serverProps get serialized into the admin client config and embedded in
+  // the RSC payload of the HTML response, so anything passed here is public.
+  // Strip secret and socialProviders[*].clientSecret before handing them off.
+  const safePluginOptions = stripSecretsFromPluginOptions(pluginOptions);
+
   config.admin = {
     ...config.admin,
     components: {
@@ -32,7 +38,7 @@ export function applyBetterAuthAdminConfig({
         {
           path: "payload-auth/better-auth/plugin/rsc#RSCRedirect",
           serverProps: {
-            pluginOptions,
+            pluginOptions: safePluginOptions,
             redirectTo: `${config.routes?.admin === undefined ? "/admin" : config.routes.admin.replace(/\/+$/, "")}${adminRoutes.adminLogin}`
           }
         },
@@ -50,7 +56,7 @@ export function applyBetterAuthAdminConfig({
           Component: {
             path: "payload-auth/better-auth/plugin/rsc#AdminLogin",
             serverProps: {
-              pluginOptions,
+              pluginOptions: safePluginOptions,
               adminInvitationsSlug:
                 collectionMap[baseSlugs.adminInvitations].slug
             }
@@ -61,7 +67,7 @@ export function applyBetterAuthAdminConfig({
           Component: {
             path: "payload-auth/better-auth/plugin/rsc#AdminSignup",
             serverProps: {
-              pluginOptions,
+              pluginOptions: safePluginOptions,
               adminInvitationsSlug:
                 collectionMap[baseSlugs.adminInvitations].slug
             }
@@ -72,7 +78,7 @@ export function applyBetterAuthAdminConfig({
           Component: {
             path: "payload-auth/better-auth/plugin/rsc#ForgotPassword",
             serverProps: {
-              pluginOptions
+              pluginOptions: safePluginOptions
             }
           }
         },
@@ -81,7 +87,7 @@ export function applyBetterAuthAdminConfig({
           Component: {
             path: "payload-auth/better-auth/plugin/rsc#ResetPassword",
             serverProps: {
-              pluginOptions
+              pluginOptions: safePluginOptions
             }
           }
         },
@@ -94,7 +100,7 @@ export function applyBetterAuthAdminConfig({
             Component: {
               path: "payload-auth/better-auth/plugin/rsc#TwoFactorVerify",
               serverProps: {
-                pluginOptions: pluginOptions,
+                pluginOptions: safePluginOptions,
                 verificationsSlug:
                   resolvedBetterAuthSchemas[baModelKey.verification].modelName
               }

--- a/packages/payload-auth/src/better-auth/plugin/lib/strip-secrets.ts
+++ b/packages/payload-auth/src/better-auth/plugin/lib/strip-secrets.ts
@@ -1,0 +1,38 @@
+import type { PayloadAuthOptions } from "../types";
+
+/**
+ * Returns a shallow clone of `pluginOptions` with secret values removed:
+ *
+ *  - `betterAuthOptions.secret`
+ *  - `betterAuthOptions.socialProviders[*].clientSecret`
+ *
+ * This is intended for values that will be passed as `serverProps` to admin
+ * view components. Payload serializes view `serverProps` into the admin
+ * client config, which ends up in the RSC payload of the HTML response, so
+ * anything in `serverProps` is visible to anyone who can load the login page.
+ *
+ * `clientId` is preserved — it is public by design and needed to render the
+ * "Sign in with <provider>" button.
+ */
+export function stripSecretsFromPluginOptions(
+  pluginOptions: PayloadAuthOptions
+): PayloadAuthOptions {
+  const clone: PayloadAuthOptions = { ...pluginOptions };
+  if (!clone.betterAuthOptions) return clone;
+
+  const ba = { ...clone.betterAuthOptions };
+  delete (ba as Record<string, unknown>).secret;
+
+  if (ba.socialProviders) {
+    ba.socialProviders = Object.fromEntries(
+      Object.entries(ba.socialProviders).map(([provider, cfg]) => {
+        if (!cfg || typeof cfg !== "object") return [provider, cfg];
+        const { clientSecret: _cs, ...rest } = cfg as Record<string, unknown>;
+        return [provider, rest];
+      })
+    ) as typeof ba.socialProviders;
+  }
+
+  clone.betterAuthOptions = ba;
+  return clone;
+}

--- a/packages/payload-auth/src/better-auth/tests/plugin/strip-secrets.test.ts
+++ b/packages/payload-auth/src/better-auth/tests/plugin/strip-secrets.test.ts
@@ -1,0 +1,129 @@
+import type { CollectionConfig, Config } from "payload";
+import { describe, expect, it } from "vitest";
+import { applyBetterAuthAdminConfig } from "../../plugin/lib/apply-ba-admin-config";
+import { stripSecretsFromPluginOptions } from "../../plugin/lib/strip-secrets";
+import type { BetterAuthSchemas, PayloadAuthOptions } from "../../plugin/types";
+
+const SECRET_SENTINEL = "test-secret-leak-sentinel";
+const CLIENT_SECRET_SENTINEL = "test-client-secret-sentinel";
+const APPLE_SECRET_SENTINEL = "test-apple-client-secret-sentinel";
+const CLIENT_ID_SENTINEL = "test-client-id-should-survive";
+
+const baseCollectionMap: Record<string, CollectionConfig> = {
+  "admin-invitations": {
+    slug: "admin-invitations",
+    fields: []
+  }
+};
+
+const baseSchemas = {
+  verification: { modelName: "verifications" }
+} as unknown as BetterAuthSchemas;
+
+function buildPluginOptions(): PayloadAuthOptions {
+  return {
+    betterAuthOptions: {
+      secret: SECRET_SENTINEL,
+      socialProviders: {
+        google: {
+          clientId: CLIENT_ID_SENTINEL,
+          clientSecret: CLIENT_SECRET_SENTINEL
+        },
+        apple: {
+          clientId: "apple-client-id",
+          clientSecret: APPLE_SECRET_SENTINEL
+        }
+      }
+    }
+  } as PayloadAuthOptions;
+}
+
+describe("stripSecretsFromPluginOptions", () => {
+  it("removes betterAuthOptions.secret", () => {
+    const stripped = stripSecretsFromPluginOptions(buildPluginOptions());
+    expect(
+      (stripped.betterAuthOptions as Record<string, unknown>)?.secret
+    ).toBeUndefined();
+  });
+
+  it("removes clientSecret from every social provider", () => {
+    const stripped = stripSecretsFromPluginOptions(buildPluginOptions());
+    const providers = stripped.betterAuthOptions?.socialProviders ?? {};
+    for (const [, cfg] of Object.entries(providers)) {
+      expect((cfg as Record<string, unknown>)?.clientSecret).toBeUndefined();
+    }
+  });
+
+  it("preserves clientId (public, required to render OAuth buttons)", () => {
+    const stripped = stripSecretsFromPluginOptions(buildPluginOptions());
+    const google = stripped.betterAuthOptions?.socialProviders?.google as
+      | Record<string, unknown>
+      | undefined;
+    expect(google?.clientId).toBe(CLIENT_ID_SENTINEL);
+  });
+
+  it("does not mutate the input", () => {
+    const input = buildPluginOptions();
+    stripSecretsFromPluginOptions(input);
+    expect(
+      (input.betterAuthOptions as Record<string, unknown>)?.secret
+    ).toBe(SECRET_SENTINEL);
+    const google = input.betterAuthOptions?.socialProviders?.google as
+      | Record<string, unknown>
+      | undefined;
+    expect(google?.clientSecret).toBe(CLIENT_SECRET_SENTINEL);
+  });
+
+  it("handles pluginOptions without betterAuthOptions", () => {
+    const stripped = stripSecretsFromPluginOptions(
+      {} as unknown as PayloadAuthOptions
+    );
+    expect(stripped).toEqual({});
+  });
+
+  it("handles betterAuthOptions without socialProviders", () => {
+    const stripped = stripSecretsFromPluginOptions({
+      betterAuthOptions: { secret: SECRET_SENTINEL }
+    } as unknown as PayloadAuthOptions);
+    expect(
+      (stripped.betterAuthOptions as Record<string, unknown>)?.secret
+    ).toBeUndefined();
+  });
+});
+
+describe("applyBetterAuthAdminConfig — serverProps do not leak secrets", () => {
+  it("serialized config.admin contains no secret or clientSecret sentinels", () => {
+    const config: Config = {} as Config;
+    applyBetterAuthAdminConfig({
+      config,
+      pluginOptions: buildPluginOptions(),
+      collectionMap: baseCollectionMap,
+      resolvedBetterAuthSchemas: baseSchemas
+    });
+
+    const serialized = JSON.stringify(config.admin);
+    expect(serialized).not.toContain(SECRET_SENTINEL);
+    expect(serialized).not.toContain(CLIENT_SECRET_SENTINEL);
+    expect(serialized).not.toContain(APPLE_SECRET_SENTINEL);
+    // Sanity: clientId must survive — the login UI needs it.
+    expect(serialized).toContain(CLIENT_ID_SENTINEL);
+  });
+
+  it("does not mutate the secrets on the caller's pluginOptions", () => {
+    const pluginOptions = buildPluginOptions();
+    applyBetterAuthAdminConfig({
+      config: {} as Config,
+      pluginOptions,
+      collectionMap: baseCollectionMap,
+      resolvedBetterAuthSchemas: baseSchemas
+    });
+
+    expect(
+      (pluginOptions.betterAuthOptions as Record<string, unknown>)?.secret
+    ).toBe(SECRET_SENTINEL);
+    const google = pluginOptions.betterAuthOptions?.socialProviders?.google as
+      | Record<string, unknown>
+      | undefined;
+    expect(google?.clientSecret).toBe(CLIENT_SECRET_SENTINEL);
+  });
+});


### PR DESCRIPTION
## Security impact

`applyBetterAuthAdminConfig` passes the entire `pluginOptions` as `serverProps` to several admin view components (`adminLogin`, `adminSignup`, `forgotPassword`, `resetPassword`, `twoFactorVerify`, plus the `afterLogin` RSC). Payload serializes view `serverProps` into the admin client config, and that config is embedded in the RSC payload of the HTML response.

Result: `betterAuthOptions.secret` and `socialProviders[provider].clientSecret` are rendered in cleartext inside every `/admin/login` HTML response. Any visitor can view-source and extract them.

## Reproduction on current `main`

```bash
curl -s http://localhost:3000/admin/login \
  | grep -oE '\\"secret\\":\\"[^\\]*\\"|\\"clientSecret\\":\\"[^\\]*\\"'
```

Prints the raw secret and every configured social provider's `clientSecret`. (The values show up in JSON-escaped form inside an RSC payload, hence the `\"` pattern.)

## Fix

- Add `stripSecretsFromPluginOptions()` helper that shallow-clones `pluginOptions` and removes `betterAuthOptions.secret` and every `betterAuthOptions.socialProviders[*].clientSecret`.
- Call it once in `applyBetterAuthAdminConfig` and use the result for all `serverProps`.
- Added regression test that asserts sentinel values don't survive serialization of the resulting `config.admin`.

## Compatibility

No runtime behavior change. The RSC views read `secret` via `initBetterAuth` on the server and the client never needed it. `clientSecret` is similarly only used in the server-side OAuth exchange. `clientId` is explicitly preserved — it's public by design and the login UI needs it to render the "Sign in with <provider>" button.

## Severity

Medium-to-high. Anyone using this plugin in production is leaking their auth secrets to any visitor of their admin login page.

## Test results

- New suite `strip-secrets.test.ts`: 8 passing (stripping behavior + end-to-end assertion that no sentinel values appear in `JSON.stringify(config.admin)`).
- `pnpm --filter payload-auth build` succeeds.
- The 13 pre-existing e2e/adapter suite failures (`Cannot find package 'payload-auth/better-auth/adapter'` from unbuilt subpath exports) reproduce on `main` without this change and are unrelated.